### PR TITLE
timezones fix

### DIFF
--- a/src/main/scala/com/coralogix/jdbc/Conversions.scala
+++ b/src/main/scala/com/coralogix/jdbc/Conversions.scala
@@ -53,7 +53,7 @@ object Conversions {
       formatter.parseBest(s, OffsetDateTime.from(_), LocalDateTime.from(_), LocalDate.from(_))
     ).toOption.map({
       case a: OffsetDateTime => a.toInstant
-      case a: LocalDateTime  => a.toInstant(ZoneOffset.of(zone.getId))
+      case a: LocalDateTime  => a.toInstant(zone.getRules.getOffset(a))
       case a: LocalDate      => a.atStartOfDay(zone).toInstant
     })
 


### PR DESCRIPTION
Tableau is using `Calendar` version of `getTimestamp` and it was failign with `Invalid ID for ZoneOffset, invalid format: UTC`